### PR TITLE
Add a complete example

### DIFF
--- a/examples/complete_example.py
+++ b/examples/complete_example.py
@@ -9,7 +9,12 @@ from kunefe import Kunefe
 
 ## generate an apptainer image
 # initialize kunefe by providing connection details
+
+# run using xenon
 # kunefe = Kunefe(username="xenon", hostname="localhost", port=10022)
+# home_folder = "/home/xenon/"
+
+# run on snellius
 kunefe = Kunefe(username="olyashevska", hostname="snellius.surf.nl", port=22)
 home_folder = "/home/olyashevska/"
 
@@ -21,23 +26,25 @@ try:
 except FileExistsError:
     print(f"Directory '{local_folder}' already exists.")
 
+# specify the Docker image to use
 version = "6.3.0"
 docker_image = f"comses/netlogo:{version}"
 sif_file_name = "netlogo_6.3.0.sif"
 local_sif_file_path = local_folder + sif_file_name
-# remote_folder = "/home/xenon/test_folder/"
+
 remote_folder = home_folder + "test_folder/"
 remote_sif_file_path = remote_folder + sif_file_name
 
 # build apptainer image from a Docker image
-kunefe.build_apptainer_image(docker_image=docker_image, sif_file_name=local_sif_file_path)
+kunefe.build_apptainer_image(
+    docker_image=docker_image, sif_file_name=local_sif_file_path
+)
 
 kunefe.connect_remote()
 
 kunefe.create_remote_folder(remote_folder=remote_folder)
 
 ## generate a job script
-# TODO place files in the correct location
 netlogo_command = """/opt/netlogo/netlogo-headless.sh \
 --model 'model_path' \
 --experiment 'experiment_name' \

--- a/examples/complete_example.py
+++ b/examples/complete_example.py
@@ -1,0 +1,58 @@
+"""A complete example to test kunefe module."""
+
+from kunefe import Kunefe
+
+## generate an apptainer image
+# initialize kunefe by providing connection details
+kunefe = Kunefe(username="xenon", hostname="localhost", port=10022)
+
+netlogo_version = "6.3.0"
+netlogo_docker_image = f"comses/netlogo:{netlogo_version}"
+netlogo_sif_file_name = "netlogo_6.3.0.sif"
+
+# build apptainer image from a Docker image
+kunefe.build_apptainer_image(docker_image=netlogo_docker_image, sif_file_name=netlogo_sif_file_name)
+
+## generate a job script
+# netlogo command to run simulation in headless mode
+netlogo_command = """/opt/netlogo/netlogo-headless.sh \
+--model 'model_path' \
+--experiment 'experiment_name' \
+--table 'table_name'
+"""
+
+# generate a slurm job script
+kunefe.generate_job_script(
+    job_name="kunefe_netlogo_experiment_job",
+    sif_file_path="/home/xenon/netlogo_6.3.0.sif",
+    command=netlogo_command,
+    env_vars="JAVA_TOOL_OPTIONS=-Xmx8G",
+    job_time="0:30:00",
+    template_name="generic",
+)
+
+## copy the required files and the job script to the remote system
+
+# # copy files to the server
+# kunefe.put_files(
+#     remote_folder="/home/xenon/",
+#     local_folder="./test_folder"
+# )
+
+## submit the job
+# kunefe.connect_remote()
+
+# # submit a new job
+# job_id, stdin, stdout, stderr = kunefe.submit_job(
+#     job_file="/home/xenon/test-slurm.job"
+# )
+
+## monitor the queue
+# kunefe.watch_slurm_queue()
+
+## retrive the job results
+
+# kunefe.get_files(
+#     remote_folder="/home/xenon/test_folder",
+#     local_folder="./copy_of_test_folder"
+# )

--- a/examples/complete_example.py
+++ b/examples/complete_example.py
@@ -1,58 +1,71 @@
-"""A complete example to test kunefe module."""
+"""A complete example showing how to test kunefe module."""
 
+import os
 from kunefe import Kunefe
+
+# set up a local slurm cluster
+# docker pull xenonmiddleware/slurm:latest
+# docker run --detach --publish 10022:22 xenonmiddleware/slurm:latest
 
 ## generate an apptainer image
 # initialize kunefe by providing connection details
-kunefe = Kunefe(username="xenon", hostname="localhost", port=10022)
+# kunefe = Kunefe(username="xenon", hostname="localhost", port=10022)
+kunefe = Kunefe(username="olyashevska", hostname="snellius.surf.nl", port=22)
+home_folder = "/home/olyashevska/"
 
-netlogo_version = "6.3.0"
-netlogo_docker_image = f"comses/netlogo:{netlogo_version}"
-netlogo_sif_file_name = "netlogo_6.3.0.sif"
+# create test folder
+local_folder = "./test_folder/"
+try:
+    os.mkdir(local_folder)
+    print(f"Directory '{local_folder}' created.")
+except FileExistsError:
+    print(f"Directory '{local_folder}' already exists.")
+
+version = "6.3.0"
+docker_image = f"comses/netlogo:{version}"
+sif_file_name = "netlogo_6.3.0.sif"
+local_sif_file_path = local_folder + sif_file_name
+# remote_folder = "/home/xenon/test_folder/"
+remote_folder = home_folder + "test_folder/"
+remote_sif_file_path = remote_folder + sif_file_name
 
 # build apptainer image from a Docker image
-kunefe.build_apptainer_image(docker_image=netlogo_docker_image, sif_file_name=netlogo_sif_file_name)
+kunefe.build_apptainer_image(docker_image=docker_image, sif_file_name=local_sif_file_path)
+
+kunefe.connect_remote()
+
+kunefe.create_remote_folder(remote_folder=remote_folder)
 
 ## generate a job script
-# netlogo command to run simulation in headless mode
+# TODO place files in the correct location
 netlogo_command = """/opt/netlogo/netlogo-headless.sh \
 --model 'model_path' \
 --experiment 'experiment_name' \
 --table 'table_name'
 """
 
-# generate a slurm job script
 kunefe.generate_job_script(
     job_name="kunefe_netlogo_experiment_job",
-    sif_file_path="/home/xenon/netlogo_6.3.0.sif",
+    sif_file_path=remote_sif_file_path,
     command=netlogo_command,
     env_vars="JAVA_TOOL_OPTIONS=-Xmx8G",
-    job_time="0:30:00",
+    job_file_path=local_folder,
+    job_time="0:1:00",
     template_name="generic",
 )
 
 ## copy the required files and the job script to the remote system
 
-# # copy files to the server
-# kunefe.put_files(
-#     remote_folder="/home/xenon/",
-#     local_folder="./test_folder"
-# )
+kunefe.put_files(remote_folder=remote_folder, local_folder=local_folder, verbose=True)
 
 ## submit the job
-# kunefe.connect_remote()
-
-# # submit a new job
-# job_id, stdin, stdout, stderr = kunefe.submit_job(
-#     job_file="/home/xenon/test-slurm.job"
-# )
+# job_id, stdin, stdout, stderr = kunefe.submit_job(job_file="/home/xenon/test_folder/kunefe_netlogo_experiment_job.sh")
+job_id, stdin, stdout, stderr = kunefe.submit_job(
+    job_file="/home/olyashevska/test_folder/kunefe_netlogo_experiment_job.sh"
+)
 
 ## monitor the queue
-# kunefe.watch_slurm_queue()
+kunefe.watch_slurm_queue()
 
 ## retrive the job results
-
-# kunefe.get_files(
-#     remote_folder="/home/xenon/test_folder",
-#     local_folder="./copy_of_test_folder"
-# )
+# kunefe.get_files(remote_folder=remote_folder, local_folder="./copy_of_test_folder")


### PR DESCRIPTION
## About
This PR provides a complete example of using Kunefe. 
 
### Changes
- Added a [python](https://github.com/mess-nlesc/kunefe/blob/feature/issue-26/add-a-complete-example/examples/complete_example.py) script which demonstrates how to convert an existing Docker image into an Apptainer, generate scripts for jobs, submit job to HPC and connect to a remote host via SSH.

## Review instructions
### Requirements
- Apptainer 1.2.5 or newer 
- Python 3.11.X or newer
- Bash shell
- Docker

### Instructions
Follow steps outlined in the file.

## Related issues
- #36 